### PR TITLE
refactor: use shared image constant for navigation logo

### DIFF
--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -2,10 +2,9 @@
   import { page } from '$app/stores';
   import { afterNavigate } from '$app/navigation';
   import { onMount } from 'svelte';
+  import { IMAGES } from '$lib/utils/image';
 
- 
-  const SIGNATURE_LOGO =
-    'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f';
+  const SIGNATURE_LOGO = IMAGES.SIGNATURE_LOGO;
 
   let mobileMenuOpen = false;
 


### PR DESCRIPTION
## Summary
- use shared image constant for navigation logo

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68b6530ee588832b9770c3228837490c