### PR TITLE
feat: defer offscreen images

### DIFF
--- a/src/lib/components/BookCard.svelte
+++ b/src/lib/components/BookCard.svelte
@@ -35,6 +35,8 @@
       alt="Cover of {book.title}"
       class="w-full h-80 object-cover"
       on:error={handleCoverError}
+      loading="lazy"
+      decoding="async"
     />
   </div>
   

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -64,6 +64,8 @@
               alt="Featured book cover"
               class="w-64 md:w-80 h-auto rounded-lg shadow-2xl transform hover:scale-105 transition-transform duration-300"
               on:error={handleBookCoverError}
+              loading="lazy"
+              decoding="async"
             />
             <div class="absolute inset-0 bg-gradient-to-r from-transparent to-black/10 rounded-lg"></div>
           </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,6 +77,8 @@
           alt="Charles W. Boswell in firefighter gear"
           class="rounded-lg shadow-xl w-full h-96 object-cover"
           on:error={(e) => e.currentTarget.style.opacity = '0.7'}
+          loading="lazy"
+          decoding="async"
         />
       </div>
       <div>


### PR DESCRIPTION
## Summary
- lazily load book cover images
- lazy-load hero book cover and author portrait

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6530e1a8c832b8e065bfe896d11de