### PR TITLE
refactor: use singular image utils import

### DIFF
--- a/src/lib/components/BookCard.svelte
+++ b/src/lib/components/BookCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Book } from '$lib/types';
-  import { createImageFallback } from '$lib/utils/images';
+  import { createImageFallback } from '$lib/utils/image';
 
   export let book: Book;
 

--- a/src/lib/components/GenreIcon.svelte
+++ b/src/lib/components/GenreIcon.svelte
@@ -1,6 +1,6 @@
 <!-- src/lib/components/GenreIcon.svelte -->
 <script lang="ts">
-  import { IMAGES } from '$lib/utils/images';
+    import { IMAGES } from '$lib/utils/image';
   
   export let genre: 'faith' | 'epic' = 'faith';
   export let size: 'small' | 'medium' | 'large' = 'medium';
@@ -63,7 +63,7 @@
 <!-- Updated Hero Component with Genre Support -->
 <!-- src/lib/components/Hero.svelte -->
 <script lang="ts">
-  import { IMAGES } from '$lib/utils/images';
+    import { IMAGES } from '$lib/utils/image';
   import GenreIcon from './GenreIcon.svelte';
 
   export let title = 'Epic Fantasy Born from Real Experience';

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { IMAGES } from '$lib/utils/images';
+    import { IMAGES } from '$lib/utils/image';
 
   export let title = 'Epic Fantasy Born from Real Experience';
   export let subtitle = 'From Navy decks to wildfire frontlines, now crafting tales of courage, brotherhood, and faith.';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import Hero from '$lib/components/Hero.svelte';
   import BookCard from '$lib/components/BookCard.svelte';
   import NewsletterSignup from '$lib/components/NewsletterSignup.svelte';
-  import { IMAGES } from '$lib/utils/images';
+    import { IMAGES } from '$lib/utils/image';
   import type { Book } from '$lib/types';
 
   // Sample data - replace with your actual data loading

--- a/src/routes/books/+page.svelte
+++ b/src/routes/books/+page.svelte
@@ -3,7 +3,7 @@
 ```svelte
 <script lang="ts">
   import BookCard from '$lib/components/BookCard.svelte';
-  import { IMAGES } from '$lib/utils/images';
+    import { IMAGES } from '$lib/utils/image';
   import type { Book } from '$lib/types';
 
   const allBooks: Book[] = [


### PR DESCRIPTION
## Summary
- replace `$lib/utils/images` imports with `$lib/utils/image`
- update components and pages to use singular image utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run check` *(fails: svelte-check found 296 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6530a161c832bbb614207704da273