### PR TITLE
fix: support fallback image generation on server and browser

### DIFF
--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -76,7 +76,11 @@ export class ImageLoadingService {
    */
   generateFallback(type: 'avatar' | 'book' | 'logo' | 'hero', text?: string): string {
     const svg = this.createSVGFallback(type, text);
-    return `data:image/svg+xml;base64,${btoa(svg)}`;
+    const base64 =
+      typeof window === 'undefined'
+        ? Buffer.from(svg).toString('base64')
+        : btoa(svg);
+    return `data:image/svg+xml;base64,${base64}`;
   }
 
   private createSVGFallback(type: string, text?: string): string {

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -36,7 +36,11 @@ export const IMAGES = {
         <text x="50%" y="50%" font-family="serif" font-size="24" font-weight="bold" fill="${textColor}" text-anchor="middle" dominant-baseline="middle">${text}</text>
       </svg>
     `;
-    return `data:image/svg+xml;base64,${btoa(svg)}`;
+    const base64 =
+      typeof window === 'undefined'
+        ? Buffer.from(svg).toString('base64')
+        : btoa(svg);
+    return `data:image/svg+xml;base64,${base64}`;
   }
   
   /**


### PR DESCRIPTION
## Summary
- use environment-aware base64 encoding when generating SVG fallbacks
- ensure fallback images are generated consistently in server and browser contexts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run check` *(fails: svelte-check found 300 errors and 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b6530bc2b8832bbc7ec20d5446faec