### PR TITLE
Use progressive image actions for covers and author photos

### DIFF
--- a/src/lib/components/BookCard.svelte
+++ b/src/lib/components/BookCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Book } from '$lib/types';
-  import { createImageFallback } from '$lib/utils/images';
+  import { lazyImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
 
   export let book: Book;
 
@@ -22,19 +23,14 @@
 
   $: genreText = book.genre === 'epic' ? 'Epic Fantasy' : 'Christian Fiction';
 
-  function handleCoverError(e: Event) {
-    const img = e.currentTarget as HTMLImageElement;
-    img.src = createImageFallback(book.title);
-  }
 </script>
 
 <div class="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
   <div class="aspect-w-3 aspect-h-4 bg-gray-200">
     <img
-      src={book.cover}
       alt="Cover of {book.title}"
       class="w-full h-80 object-cover"
-      on:error={handleCoverError}
+      use:lazyImage={{ src: book.cover, fallback: FALLBACK_IMAGES.BOOK_COVER }}
     />
   </div>
   

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { IMAGES } from '$lib/utils/images';
+  import { progressiveImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
 
   export let title = 'Epic Fantasy Born from Real Experience';
   export let subtitle = 'From Navy decks to wildfire frontlines, now crafting tales of courage, brotherhood, and faith.';
@@ -17,11 +19,6 @@
     img.outerHTML = `<div class="w-32 h-32 bg-red-600 text-white rounded-full flex items-center justify-center text-lg font-bold ember-glow">${fallbackText}</div>`;
   }
 
-  function handleBookCoverError(e: Event) {
-    const img = e.currentTarget as HTMLImageElement;
-    img.style.opacity = '0.7';
-    img.style.filter = 'grayscale(50%)';
-  }
 </script>
 
 <section class="fire-gradient text-white section-padding relative overflow-hidden">
@@ -63,7 +60,7 @@
               src={bookCover}
               alt="Featured book cover"
               class="w-64 md:w-80 h-auto rounded-lg shadow-2xl transform hover:scale-105 transition-transform duration-300"
-              on:error={handleBookCoverError}
+              use:progressiveImage={{ fallback: FALLBACK_IMAGES.BOOK_COVER }}
             />
             <div class="absolute inset-0 bg-gradient-to-r from-transparent to-black/10 rounded-lg"></div>
           </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,8 @@
   import BookCard from '$lib/components/BookCard.svelte';
   import NewsletterSignup from '$lib/components/NewsletterSignup.svelte';
   import { IMAGES } from '$lib/utils/images';
+  import { progressiveImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
   import type { Book } from '$lib/types';
 
   // Sample data - replace with your actual data loading
@@ -76,7 +78,7 @@
           src={IMAGES.AUTHOR_FIREFIGHTER}
           alt="Charles W. Boswell in firefighter gear"
           class="rounded-lg shadow-xl w-full h-96 object-cover"
-          on:error={(e) => e.currentTarget.style.opacity = '0.7'}
+          use:progressiveImage={{ fallback: FALLBACK_IMAGES.AUTHOR_PHOTO }}
         />
       </div>
       <div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,6 +2,8 @@
   // FIX: your util file is singular: src/lib/utils/image.ts
   // and should export IMAGES (or adjust as needed)
   import { IMAGES } from '$lib/utils/image';
+  import { progressiveImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
 </script>
 
 <svelte:head>
@@ -19,7 +21,7 @@
       <!-- Top-center oval portrait -->
       <figure class="flex justify-center mb-6">
         <img
-          src="https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58"
+          src={IMAGES.AUTHOR_PORTRAIT}
           alt="Portrait of Charles W. Boswell"
           width="320"
           height="384"
@@ -27,6 +29,7 @@
           loading="eager"
           decoding="async"
           fetchpriority="high"
+          use:progressiveImage={{ fallback: FALLBACK_IMAGES.AUTHOR_PHOTO }}
         />
       </figure>
 
@@ -48,7 +51,7 @@
           src={IMAGES.AUTHOR_PORTRAIT}
           alt="Charles W. Boswell, author portrait"
           class="rounded-lg shadow-xl w-full h-auto sticky top-8"
-          on:error={(e) => (e.currentTarget.style.opacity = '0.7')}
+          use:progressiveImage={{ fallback: FALLBACK_IMAGES.AUTHOR_PHOTO }}
         />
       </div>
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { progressiveImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
+
   type Post = {
     slug: string;
     title: string;
@@ -89,6 +92,7 @@
               class="rounded-lg my-4"
               loading="lazy"
               decoding="async"
+              use:progressiveImage={{ fallback: FALLBACK_IMAGES.BOOK_COVER }}
             />
           {/if}
 

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { progressiveImage } from '$lib/actions/progressiveImage';
+  import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
+
   type Post = {
     slug: string;
     title: string;
@@ -37,6 +40,7 @@
       class="rounded-lg my-4"
       loading="lazy"
       decoding="async"
+      use:progressiveImage={{ fallback: FALLBACK_IMAGES.BOOK_COVER }}
     />
   {/if}
 


### PR DESCRIPTION
## Summary
- apply `lazyImage` to book cover cards for progressive loading
- enhance hero and author photos with `progressiveImage` fallbacks
- ensure blog images use progressive loading with shared fallback

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*
- `npm install` *(fails: 403 Forbidden fetching @sveltejs/adapter-vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68b6530d4f44832b9fa72826db03af0a