### PR TITLE
refactor: centralize image urls

### DIFF
--- a/src/lib/data/books.ts
+++ b/src/lib/data/books.ts
@@ -1,12 +1,12 @@
 // src/lib/data/books.ts
 import type { Book } from '../types.js';
+import { IMAGES } from '$lib/utils/image';
 
 export const books: Book[] = [
   {
     id: 'faith-firestorm-epub',
     title: 'Faith in a FireStorm',
-    cover:
-      'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Faith%20in%20a%20FireStorm%20Cover.png?alt=media&token=96a07f8e-b0f6-47b4-bcba-84f581a475da',
+    cover: IMAGES.BOOKS.FAITH_FIRESTORM,
     description:
       "A faith-forward wildfire drama inspired by 16 years on the line—courage, family, and grace when everything burns. Follow characters who must rely on their faith and each other as they battle nature's most destructive force.",
     status: 'upcoming',
@@ -19,8 +19,7 @@ export const books: Book[] = [
   {
     id: 'conviction-in-a-flood-epub',
     title: 'Conviction in a Flood',
-    cover:
-      'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Conviction_in_a_Flood%20Cover.png?alt=media&token=0e9ea64f-f71c-427e-a63e-dfdc301a60c1',
+    cover: IMAGES.BOOKS.CONVICTION_FLOOD,
     description:
       "A companion novel exploring faith and resilience when rising waters test a community's resolve—where conviction must hold fast against the flood.",
     status: 'upcoming',
@@ -32,8 +31,7 @@ export const books: Book[] = [
   {
     id: 'hurricane-eve-epub',
     title: 'Hurricane Eve',
-    cover:
-      'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Hurricane_Eve%20Cover.png?alt=media&token=547854ac-b00e-411a-b5e5-e15995b01334',
+    cover: IMAGES.BOOKS.HURRICANE_EVE,
     description:
       "They said nothing could be worse than Katrina. They were wrong. In the third installment of the Faith & Calamity series, Jake Allen faces a storm that shatters records—and faith itself. As levees break and communities drown, survival demands both courage and unshakable belief.",
     status: 'upcoming',
@@ -46,8 +44,7 @@ export const books: Book[] = [
   {
     id: 'faith-of-the-hunter-epub',
     title: 'The Faith of the Hunter',
-    cover:
-      "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/20250831_2300_Hunter's%20Faith%20Adventure_simple_compose_01k41kc9cge95t9xhrte18arrn.png?alt=media&token=4182a745-4591-44ee-aa7f-1619db3bd895",
+    cover: IMAGES.BOOKS.HUNTERS_FAITH,
     description:
       "David Paczer, a modern bow designer and avid hunter, is thrust back to a brutal medieval world where the Church’s armies force conversion by sword. With only his faith, skills, and an odd feline companion, David must survive, protect the innocent, and discover God’s purpose in a land at war.",
     status: 'upcoming',
@@ -60,8 +57,7 @@ export const books: Book[] = [
   {
     id: 'heart-of-the-storm-epub',
     title: 'Heart of the Storm',
-    cover:
-      'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Heart%20of%20the%20Storm_%20Elf%20and%20Wolf.png?alt=media&token=5376fbb7-b0e4-4595-abc8-6ec96be68005',
+    cover: IMAGES.BOOKS.HEART_OF_STORM,
     description:
       'An epic fantasy of corruption, rebirth, and resilience. When a forbidden ritual tears open a breach between worlds, a young survivor named Rowetha and an aged war hero rejuvenated by a mysterious potion must face a rising darkness that wears the faces of the people they love. Ancient guardians, eldritch corruption, and the storm of destiny converge in a tale of sacrifice and hope.',
     status: 'upcoming',

--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -207,20 +207,6 @@ export class ImageLoadingService {
 // Export singleton instance
 export const imageService = ImageLoadingService.getInstance();
 
-// Common image URLs used throughout the app
-export const APP_IMAGES = {
-  SIGNATURE_LOGO: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f',
-  
-  AUTHOR_PHOTO: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58',
-  
-  FIREFIGHTER_PHOTO: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/CharlesBosewll_USFS.jpg?alt=media&token=46388a4c-27d2-4da6-9ad3-9d4c9b279e05',
-  
-  ICONS: {
-    FAITH: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/ChristianFiction.png?alt=media&token=6f8f6512-0818-44aa-8fd6-2c29b80c570d',
-    EPIC: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/EpicFantasy.png?alt=media&token=3534891a-927d-4a4b-aa82-911ea6e03025'
-  }
-} as const;
-
 // Fallback data URIs for instant loading
 export const FALLBACK_IMAGES = {
   SIGNATURE_LOGO: imageService.generateFallback('logo', 'CB'),


### PR DESCRIPTION
## Summary
- remove unused `APP_IMAGES` from imageLoading service
- use `IMAGES` constants for book covers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68b65f8dfd60832bb7793db1f0e23078