### PR TITLE
chore: remove unused image error handler

### DIFF
--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -42,16 +42,3 @@ export const IMAGES = {
         : btoa(svg);
     return `data:image/svg+xml;base64,${base64}`;
   }
-  
-  /**
-   * Simple image error handler
-   */
-  export function handleImageError(event: Event, fallback?: string) {
-    const img = event.currentTarget as HTMLImageElement;
-    if (fallback) {
-      img.src = fallback;
-    } else {
-      img.style.opacity = '0.5';
-      img.style.filter = 'grayscale(100%)';
-    }
-  }


### PR DESCRIPTION
## Summary
- drop unused `handleImageError` helper from `utils/image.ts`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b65f8cc930832bb4af8969adb6e763