### PR TITLE
fix: remove markdown artifacts from books page

### DIFF
--- a/src/routes/books/+page.svelte
+++ b/src/routes/books/+page.svelte
@@ -1,9 +1,6 @@
-## 12. Books Page (src/routes/books/+page.svelte)
-
-```svelte
 <script lang="ts">
   import BookCard from '$lib/components/BookCard.svelte';
-    import { IMAGES } from '$lib/utils/image';
+  import { IMAGES } from '$lib/utils/image';
   import type { Book } from '$lib/types';
 
   const allBooks: Book[] = [


### PR DESCRIPTION
## Summary
- remove markdown heading and code fences from books page component
- ensure the books page starts with a Svelte script tag

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b65f89f758832bbfd3827b53ed0a3c