### PR TITLE
Instantiate DOMPurify before sanitizing markdown

### DIFF
--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -2,7 +2,9 @@
 import { marked } from 'marked';
 import createDOMPurify from 'isomorphic-dompurify';
 
+const DOMPurify = createDOMPurify();
+
 export function mdToHtml(md: string) {
   const dirty = marked.parse(md ?? '');
-  return createDOMPurify.sanitize(dirty as string);
+  return DOMPurify.sanitize(dirty as string);
 }


### PR DESCRIPTION
## Summary
- Instantiate DOMPurify from `isomorphic-dompurify` and use it to sanitize generated HTML

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b65f894eec832b856fca4f035a9452