### PR TITLE
refactor: centralize Firebase URL normalization

### DIFF
--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -1,5 +1,6 @@
 // src/lib/services/imageLoading.ts
 import { writable } from 'svelte/store';
+import { normalizeFirebaseUrl as normalizeUrl } from '$lib/utils/urls';
 
 /**
  * Firebase Storage URL normalization and fallback management
@@ -17,15 +18,10 @@ export class ImageLoadingService {
   }
 
   /**
-   * Normalize Firebase Storage URLs to use correct domain
+   * Normalize Firebase Storage URLs using the shared utility
    */
   normalizeFirebaseUrl(url?: string | null): string | undefined {
-    if (!url) return undefined;
-    
-    // Fix common Firebase Storage domain issues
-    return url
-      .replace('endless-fire-467204-n2.firebasestorage.app', 'endless-fire-467204-n2.appspot.com')
-      .replace(/([?&])alt=media&?/g, '$1alt=media'); // Clean up duplicate parameters
+    return normalizeUrl(url) ?? undefined;
   }
 
   /**

--- a/src/lib/utils/urls.ts
+++ b/src/lib/utils/urls.ts
@@ -1,19 +1,32 @@
 export function normalizeFirebaseUrl(url?: string | null): string | null {
-    if (!url) return null;
-    let out = url
-      .replace('endless-fire-467204-n2.firebasestorage.app', 'endless-fire-467204-n2.appspot.com')
-      .replace('https://endless-fire-467204-n2.appspot.com', 'https://firebasestorage.googleapis.com');
-    try {
-      const u = new URL(out);
-      const i = u.pathname.indexOf('/o/');
-      if (i !== -1) {
-        const before = u.pathname.slice(0, i + 3);
-        const objectRaw = u.pathname.slice(i + 3);
-        const fixed = encodeURIComponent(decodeURIComponent(objectRaw));
-        u.pathname = before + fixed;
-        out = u.toString();
-      }
-    } catch {}
-    return out;
-  }
+  if (!url) return null;
+
+  // Correct common Firebase Storage domain issues and parameter duplication
+  let out = url
+    .replace(
+      'endless-fire-467204-n2.firebasestorage.app',
+      'endless-fire-467204-n2.appspot.com'
+    )
+    .replace(
+      'https://endless-fire-467204-n2.appspot.com',
+      'https://firebasestorage.googleapis.com'
+    )
+    .replace(/([?&])alt=media&?/g, '$1alt=media');
+
+  // Ensure the object path segment is properly encoded
+  try {
+    const u = new URL(out);
+    const i = u.pathname.indexOf('/o/');
+    if (i !== -1) {
+      const before = u.pathname.slice(0, i + 3);
+      const objectRaw = u.pathname.slice(i + 3);
+      const fixed = encodeURIComponent(decodeURIComponent(objectRaw));
+      u.pathname = before + fixed;
+      out = u.toString();
+    }
+  } catch {}
+
+  return out;
+}
+
   

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,15 +2,7 @@
 import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db';
 import { getFeaturedBook, type BookDoc } from '$lib/server/books';
-
-/** Normalize older firebase domain variants to the standard appspot host. */
-function normalizeFirebaseUrl(url?: string | null): string | null {
-  if (!url) return null;
-  return url.replace(
-    'endless-fire-467204-n2.firebasestorage.app',
-    'endless-fire-467204-n2.appspot.com'
-  );
-}
+import { normalizeFirebaseUrl } from '$lib/utils/urls';
 
 /** Public, JSON-serializable shape for the client */
 type PublicBook = {

--- a/src/routes/blog/+page.server.ts
+++ b/src/routes/blog/+page.server.ts
@@ -2,10 +2,7 @@ import type { PageServerLoad } from './$types';
 import { getPublishedPosts, getAllTags } from '$lib/server/posts';
 import { mdToHtml } from '$lib/server/markdown';
 import { env } from '$env/dynamic/private';
-
-function normalizeFirebaseUrl(url?: string | null): string | undefined {
-  return url?.replace('endless-fire-467204-n2.firebasestorage.app', 'endless-fire-467204-n2.appspot.com');
-}
+import { normalizeFirebaseUrl } from '$lib/utils/urls';
 
 export const load: PageServerLoad = async ({ url }) => {
   const page = Number(url.searchParams.get('page') ?? '1');
@@ -19,7 +16,7 @@ export const load: PageServerLoad = async ({ url }) => {
     slug: p.slug,
     title: p.title,
     excerpt: p.excerpt,
-    heroImage: normalizeFirebaseUrl(p.heroImage),
+    heroImage: normalizeFirebaseUrl(p.heroImage) ?? undefined,
     publishDate: p.publishDate ?? undefined,
     tags: p.tags ?? [],
     genre: p.genre,

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -2,10 +2,7 @@ import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { getPostBySlug } from '$lib/server/posts';
 import { mdToHtml } from '$lib/server/markdown';
-
-function normalizeFirebaseUrl(url?: string | null): string | undefined {
-  return url?.replace('endless-fire-467204-n2.firebasestorage.app', 'endless-fire-467204-n2.appspot.com');
-}
+import { normalizeFirebaseUrl } from '$lib/utils/urls';
 
 export const load: PageServerLoad = async ({ params }) => {
   const post = await getPostBySlug(params.slug);
@@ -14,7 +11,7 @@ export const load: PageServerLoad = async ({ params }) => {
   return {
     post: {
       ...post,
-      heroImage: normalizeFirebaseUrl(post.heroImage),
+      heroImage: normalizeFirebaseUrl(post.heroImage) ?? undefined,
       contentHtml: mdToHtml(post.contentMarkdown ?? '')
     }
   };


### PR DESCRIPTION
## Summary
- consolidate Firebase URL normalization into shared `normalizeFirebaseUrl` utility
- reuse shared helper in `ImageLoadingService` and server loaders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run check` *(fails: svelte-check found 29 errors and 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b740878e84832b850c1053fdf512c3