### PR TITLE
feat: centralize image utilities

### DIFF
--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -1,4 +1,32 @@
 // lib/utils/image.ts
+import { imageService } from '$lib/services/imageLoading';
+
+// Helper to build Firebase Storage URLs
+const fb = (path: string) =>
+  `https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/${encodeURIComponent(
+    path
+  )}?alt=media`;
+
+// Centralized mapping of image assets used across the app
+export const IMAGES = {
+  SIGNATURE_LOGO: '/file.svg',
+  AUTHOR_PORTRAIT: fb('author/portrait.jpg'),
+  AUTHOR_FIREFIGHTER: fb('author/firefighter.jpg'),
+  BOOKS: {
+    FAITH_FIRESTORM: fb('books/faith-firestorm.jpg'),
+    CONVICTION_FLOOD: fb('books/conviction-in-a-flood.jpg'),
+    HURRICANE_EVE: fb('books/hurricane-eve.jpg'),
+    HUNTERS_FAITH: fb('books/hunters-faith.jpg'),
+    HEART_OF_STORM: fb('books/heart-of-the-storm.jpg'),
+    FAITH_IN_A_FIRESTORM: fb('books/faith-in-a-firestorm.jpg'),
+    CONVICTION_IN_A_FLOOD: fb('books/conviction-in-a-flood.jpg'),
+    THE_FAITH_OF_THE_HUNTER: fb('books/the-faith-of-the-hunter.jpg')
+  }
+} as const;
+
+// Convenience wrapper so consumers don't depend on the service directly
+export const preloadImage = (src: string) => imageService.preloadImage(src);
+
 function base64EncodeUtf8(s: string) {
   if (typeof window === 'undefined') {
     return Buffer.from(s, 'utf-8').toString('base64');


### PR DESCRIPTION
## Summary
- add IMAGES map of static/Firebase assets
- expose preloadImage wrapper around imageService

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package 'prettier-plugin-tailwindcss')
- `npm run check` (fails: svelte-check found 23 errors)

------
https://chatgpt.com/codex/tasks/task_e_68b740856aa0832b89a0c2dcdce23864