### PR TITLE
feat: load books from database

### DIFF
--- a/src/routes/books/+page.server.ts
+++ b/src/routes/books/+page.server.ts
@@ -1,0 +1,60 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db';
+import type { BookDoc } from '$lib/server/books';
+
+// normalize older firebase domain variants to the standard appspot host
+function normalizeFirebaseUrl(url?: string | null): string | null {
+  if (!url) return null;
+  return url.replace(
+    'endless-fire-467204-n2.firebasestorage.app',
+    'endless-fire-467204-n2.appspot.com'
+  );
+}
+
+export const load: PageServerLoad = async () => {
+  const db = await getDb();
+
+  const docs = await db
+    .collection<BookDoc>('books')
+    .find(
+      {},
+      {
+        projection: {
+          _id: 0,
+          id: 1,
+          title: 1,
+          description: 1,
+          cover: 1,
+          genre: 1,
+          status: 1,
+          publishDate: 1,
+          isbn: 1,
+          format: 1,
+          pages: 1,
+          buyLinks: 1
+        }
+      }
+    )
+    .toArray();
+
+  const books = docs.map((b) => ({
+    id: b.id,
+    title: b.title,
+    description: b.description ?? null,
+    cover: normalizeFirebaseUrl((b as any).cover),
+    genre: b.genre ?? null,
+    status: b.status ?? null,
+    publishDate: b.publishDate
+      ? b.publishDate instanceof Date
+        ? b.publishDate.toISOString()
+        : String(b.publishDate)
+      : null,
+    isbn: b.isbn ?? null,
+    format: (b as any).format ?? null,
+    pages: (b as any).pages ?? null,
+    buyLinks: (b as any).buyLinks ?? null
+  }));
+
+  return { books };
+};
+

--- a/src/routes/books/+page.svelte
+++ b/src/routes/books/+page.svelte
@@ -3,7 +3,9 @@
   import { IMAGES } from '$lib/utils/image';
   import type { Book } from '$lib/types';
 
-  const allBooks: Book[] = [
+  export let data: { books: Book[] };
+
+  const fallbackBooks: Book[] = [
     {
       id: 'faith-in-firestorm',
       title: 'Faith in a Firestorm',
@@ -55,11 +57,12 @@
       status: 'writing'
     }
   ];
+    const books: Book[] = data?.books?.length ? data.books : fallbackBooks;
 
   let selectedGenre: 'all' | 'faith' | 'epic' = 'all';
   let selectedStatus: 'all' | 'published' | 'coming-soon' | 'writing' = 'all';
 
-  $: filteredBooks = allBooks.filter(book => {
+  $: filteredBooks = books.filter(book => {
     const genreMatch = selectedGenre === 'all' || book.genre === selectedGenre;
     const statusMatch = selectedStatus === 'all' || book.status === selectedStatus;
     return genreMatch && statusMatch;


### PR DESCRIPTION
## Summary
- load books from MongoDB and normalize Firebase URLs
- update books page to consume server-provided data with guarded fallback

## Testing
- `npm test` (missing script: "test")
- `npm run lint` (Cannot find package 'prettier-plugin-tailwindcss')
- `npm run check` (svelte-check found 29 errors and 3 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b74086b724832b9f39e4ceb9926407