### PR TITLE
Add robust Hero component markup

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import GenreIcon from './GenreIcon.svelte';
   import { createImageFallback } from '$lib/utils/image';
   import { normalizeFirebaseUrl } from '$lib/utils/urls'; // ✅ make sure this exists
 
@@ -46,3 +45,29 @@
     img.style.opacity = '1';
   }
 </script>
+
+<section class={`relative text-white py-20 overflow-hidden ${gradientClass}`}>
+  <div class="max-w-7xl mx-auto px-4 flex flex-col md:flex-row items-center gap-8">
+    {#if coverSrc}
+      <div class="w-48 h-72 flex-shrink-0">
+        <img
+          src={coverSrc}
+          alt={`${title} cover`}
+          class="w-full h-full object-cover rounded shadow-lg transition-opacity duration-300"
+          on:error={dimOrFallback}
+        />
+      </div>
+    {/if}
+
+    <div class="text-center md:text-left">
+      <h1 class="text-4xl md:text-5xl font-bold mb-4">{title}</h1>
+      <p class="text-xl mb-8">{subtitle}</p>
+      <a
+        href={ctaLink}
+        class={`inline-block px-8 py-4 rounded-lg font-semibold ${ctaStyle}`}
+      >
+        {ctaText}
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- Implement full Hero section markup and remove stray self-closing tags
- Remove unused GenreIcon import and rely on component props directly

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92bc51164832ba497036b146b199b