### PR TITLE
refactor: update rss feed posts retrieval

### DIFF
--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { getPublishedPosts } from '$lib/server/posts';
 
 export const GET: RequestHandler = async () => {
-  const { items } = await getPublishedPosts(1, 20);
+  const items = await getPublishedPosts(20);
   const site = 'https://your-domain.com';
 
   const itemsXml = items


### PR DESCRIPTION
## Summary
- fetch posts for RSS feed using simplified getPublishedPosts signature

## Testing
- `npm run check` *(fails: Object literal may only specify known properties, and '"featured"' does not exist in type '{ book: Book; }'...)*

------
https://chatgpt.com/codex/tasks/task_e_68b92f8d24d8832bba7d46f25a3f8d58