### PR TITLE
Add line-clamp property to support standard CSS

### DIFF
--- a/src/lib/components/BookCard.svelte
+++ b/src/lib/components/BookCard.svelte
@@ -109,6 +109,7 @@
   .line-clamp-2 {
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -153,6 +153,7 @@
   .line-clamp-3 {
     display: -webkit-box;
     -webkit-line-clamp: 3;
+    line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }


### PR DESCRIPTION
## Summary
- Add standard CSS `line-clamp` for two-line and three-line text truncation

## Testing
- `npm run check` *(fails: Property 'createTransporter' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_68b92f908ebc832b9ac689f5c5608363