### PR TITLE
refactor: centralize firebase url normalization

### DIFF
--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -5,91 +5,82 @@ import { browser } from '$app/environment';
  * CRITICAL FIX: Firebase Storage URLs with proper typing
  */
 export const FIREBASE_IMAGES = {
-  BOOKS: {
-    FAITH_IN_A_FIRESTORM: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3',
-    CONVICTION_IN_A_FLOOD: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Conviction_in_a_Flood.png?alt=media&token=0e509deb-cc0f-4f2d-9852-d7fab2f28741',
-    HURRICANE_EVE: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Hurrican_Eve.png?alt=media&token=cac22f0d-d0c8-4965-b6be-d743a3968148',
-    THE_FAITH_OF_THE_HUNTER: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/The_Faith_of_the_Hunter.png?alt=media&token=17825380-c90b-41d3-b16e-dc04cac14a69',
-    HEART_OF_THE_STORM: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Heart_of_the_Storm.png?alt=media&token=a289b1cc-87c1-402c-a920-00e895ddf4cd',
-    SYMBIOGENESIS: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Symbiogenesis.png?alt=media&token=f9a763d8-bc7e-49d5-8bb2-afe2596ac023'
-  },
-  AUTHOR: {
-    PORTRAIT: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBoswell.jpg?alt=media&token=1ba4211f-b06c-49c3-9ef9-96e75fccc8e0',
-    FIREFIGHTER: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBosewll_USFS.jpg?alt=media&token=46388a4c-27d2-4da6-9ad3-9d4c9b279e05',
-    NAVY: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Navy1993.JPG?alt=media&token=c1be8697-f87e-404b-b6df-8d3d856f2140',
-    AUGUST_25: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58'
-  },
-  ICONS: {
-    SIGNATURE_LOGO: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f',
-    CHRISTIAN_FICTION: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/ChristianFiction.png?alt=media&token=6f8f6512-0818-44aa-8fd6-2c29b80c570d',
-    EPIC_FANTASY: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/EpicFantasy.png?alt=media&token=3534891a-927d-4a4b-aa82-911ea6e03025'
-  }
+	BOOKS: {
+		FAITH_IN_A_FIRESTORM:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3',
+		CONVICTION_IN_A_FLOOD:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Conviction_in_a_Flood.png?alt=media&token=0e509deb-cc0f-4f2d-9852-d7fab2f28741',
+		HURRICANE_EVE:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Hurrican_Eve.png?alt=media&token=cac22f0d-d0c8-4965-b6be-d743a3968148',
+		THE_FAITH_OF_THE_HUNTER:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/The_Faith_of_the_Hunter.png?alt=media&token=17825380-c90b-41d3-b16e-dc04cac14a69',
+		HEART_OF_THE_STORM:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Heart_of_the_Storm.png?alt=media&token=a289b1cc-87c1-402c-a920-00e895ddf4cd',
+		SYMBIOGENESIS:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Symbiogenesis.png?alt=media&token=f9a763d8-bc7e-49d5-8bb2-afe2596ac023'
+	},
+	AUTHOR: {
+		PORTRAIT:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBoswell.jpg?alt=media&token=1ba4211f-b06c-49c3-9ef9-96e75fccc8e0',
+		FIREFIGHTER:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBosewll_USFS.jpg?alt=media&token=46388a4c-27d2-4da6-9ad3-9d4c9b279e05',
+		NAVY: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Navy1993.JPG?alt=media&token=c1be8697-f87e-404b-b6df-8d3d856f2140',
+		AUGUST_25:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58'
+	},
+	ICONS: {
+		SIGNATURE_LOGO:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f',
+		CHRISTIAN_FICTION:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/ChristianFiction.png?alt=media&token=6f8f6512-0818-44aa-8fd6-2c29b80c570d',
+		EPIC_FANTASY:
+			'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/EpicFantasy.png?alt=media&token=3534891a-927d-4a4b-aa82-911ea6e03025'
+	}
 } as const;
-
-/**
- * CRITICAL FIX: Safe URL normalization for Firebase Storage
- */
-export function normalizeFirebaseUrl(url: string | null | undefined): string | null {
-  if (!url || typeof url !== 'string') return null;
-  
-  // Already a valid Firebase Storage URL
-  if (url.startsWith('https://firebasestorage.googleapis.com/')) {
-    return url;
-  }
-  
-  // Legacy gs:// URL - convert to HTTPS
-  if (url.startsWith('gs://')) {
-    const path = url.replace('gs://', '').replace(/^([^/]+)\//, '$1/o/');
-    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-    return `https://firebasestorage.googleapis.com/v0/b/${encodedPath}?alt=media`;
-  }
-  
-  // Relative path - assume it's a Firebase Storage path
-  if (!url.startsWith('http')) {
-    const encodedPath = url.split('/').map(encodeURIComponent).join('/');
-    return `https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/${encodedPath}?alt=media`;
-  }
-  
-  return url;
-}
 
 /**
  * CRITICAL FIX: Generate fallback images safely
  */
 function generateFallbackImage(type: 'book' | 'avatar' | 'logo', text: string): string {
-  if (!browser) {
-    return `data:image/svg+xml;base64,${btoa('<svg xmlns="http://www.w3.org/2000/svg" width="300" height="400" viewBox="0 0 300 400"><rect width="100%" height="100%" fill="#f3f4f6"/><text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="Arial" font-size="24" fill="#6b7280">Loading...</text></svg>')}`;
-  }
+	if (!browser) {
+		return `data:image/svg+xml;base64,${btoa('<svg xmlns="http://www.w3.org/2000/svg" width="300" height="400" viewBox="0 0 300 400"><rect width="100%" height="100%" fill="#f3f4f6"/><text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="Arial" font-size="24" fill="#6b7280">Loading...</text></svg>')}`;
+	}
 
-  try {
-    const colors = {
-      book: { bg: '#dc2626', text: '#ffffff' },
-      avatar: { bg: '#059669', text: '#ffffff' },
-      logo: { bg: '#7c3aed', text: '#ffffff' }
-    };
+	try {
+		const colors = {
+			book: { bg: '#dc2626', text: '#ffffff' },
+			avatar: { bg: '#059669', text: '#ffffff' },
+			logo: { bg: '#7c3aed', text: '#ffffff' }
+		};
 
-    const { bg, text: textColor } = colors[type];
-    const dimensions = type === 'book' ? { w: 300, h: 400 } : { w: 200, h: 200 };
+		const { bg, text: textColor } = colors[type];
+		const dimensions = type === 'book' ? { w: 300, h: 400 } : { w: 200, h: 200 };
 
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${dimensions.w}" height="${dimensions.h}" viewBox="0 0 ${dimensions.w} ${dimensions.h}">
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${dimensions.w}" height="${dimensions.h}" viewBox="0 0 ${dimensions.w} ${dimensions.h}">
       <rect width="100%" height="100%" fill="${bg}"/>
       <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="${textColor}">${text}</text>
     </svg>`;
 
-    return `data:image/svg+xml;base64,${btoa(svg)}`;
-  } catch (error) {
-    console.warn('[generateFallbackImage] Error:', error);
-    return '';
-  }
+		return `data:image/svg+xml;base64,${btoa(svg)}`;
+	} catch (error) {
+		console.warn('[generateFallbackImage] Error:', error);
+		return '';
+	}
 }
 
 /**
  * CRITICAL FIX: Export FALLBACK_IMAGES that your components expect
  */
 export const FALLBACK_IMAGES = {
-  get BOOK_COVER() { return generateFallbackImage('book', 'BOOK'); },
-  get AUTHOR_PHOTO() { return generateFallbackImage('avatar', 'AUTHOR'); },
-  get LOGO() { return generateFallbackImage('logo', 'CB'); }
+	get BOOK_COVER() {
+		return generateFallbackImage('book', 'BOOK');
+	},
+	get AUTHOR_PHOTO() {
+		return generateFallbackImage('avatar', 'AUTHOR');
+	},
+	get LOGO() {
+		return generateFallbackImage('logo', 'CB');
+	}
 } as const;
 
 /**
@@ -97,3 +88,4 @@ export const FALLBACK_IMAGES = {
  * This maintains backward compatibility if other files import from here
  */
 export { progressiveImage, imagePreloader } from '$lib/actions/progressiveImage';
+export { normalizeFirebaseUrl } from '$lib/utils/urls';

--- a/src/lib/utils/urls.ts
+++ b/src/lib/utils/urls.ts
@@ -1,76 +1,85 @@
 // src/lib/utils/urls.ts - FIXED to handle both domains
 export function sanitizeFirebaseUrl(u?: string | null): string | null {
-  if (!u) return null;
-  
-  let cleaned = u.trim().replace(/^['"]+|['"]+$/g, '').replace(/%22$/, '');
-  
-  try {
-    cleaned = decodeURIComponent(cleaned);
-  } catch {
-    // If decoding fails, use original
-  }
-  
-  return cleaned;
+	if (!u) return null;
+
+	let cleaned = u
+		.trim()
+		.replace(/^['"]+|['"]+$/g, '')
+		.replace(/%22$/, '');
+
+	try {
+		cleaned = decodeURIComponent(cleaned);
+	} catch {
+		// If decoding fails, use original
+	}
+
+	return cleaned;
 }
 
 export function normalizeFirebaseUrl(u?: string | null): string | null {
-  return sanitizeFirebaseUrl(u);
+	const url = toFirebaseDownloadIfNeeded(u);
+	if (!url) return null;
+
+	if (url.startsWith('http')) return url;
+
+	const encodedPath = url.split('/').map(encodeURIComponent).join('/');
+	return `https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/${encodedPath}?alt=media`;
 }
 
 /**
  * ✅ FIXED: Convert Firebase URLs to working format
  */
 export function toFirebaseDownloadIfNeeded(u?: string | null): string | null {
-  const url = sanitizeFirebaseUrl(u);
-  if (!url) return null;
+	const url = sanitizeFirebaseUrl(u);
+	if (!url) return null;
 
-  try {
-    const uo = new URL(url);
-    
-    // ✅ FIX: Convert old appspot.com URLs to firebasestorage.app
-    if (uo.hostname === 'firebasestorage.googleapis.com' && uo.pathname.startsWith('/v0/b/')) {
-      // Extract bucket name from path
-      const pathParts = uo.pathname.split('/');
-      const bucketName = pathParts[3]; // /v0/b/{bucket}/o/...
-      
-      // If it's the old appspot.com format, convert to firebasestorage.app
-      if (bucketName.endsWith('.appspot.com')) {
-        const newBucket = bucketName.replace('.appspot.com', '.firebasestorage.app');
-        uo.pathname = uo.pathname.replace(bucketName, newBucket);
-        return uo.toString();
-      }
-      
-      return url; // Already correct format
-    }
-    
-    // Handle gs:// URLs
-    if (url.startsWith('gs://')) {
-      const without = url.slice(5);
-      const i = without.indexOf('/');
-      const bucket = i === -1 ? without : without.slice(0, i);
-      const objectPath = i === -1 ? '' : without.slice(i + 1);
-      
-      // Use the correct firebasestorage.app domain
-      const correctBucket = bucket.endsWith('.appspot.com') 
-        ? bucket.replace('.appspot.com', '.firebasestorage.app')
-        : bucket;
-      
-      const encoded = encodeURIComponent(objectPath);
-      return `https://firebasestorage.googleapis.com/v0/b/${correctBucket}/o/${encoded}?alt=media`;
-    }
-    
-    // Handle .firebasestorage.app URLs (correct format)
-    if (uo.hostname.endsWith('.firebasestorage.app')) {
-      const bucket = uo.hostname;
-      const rawPath = uo.pathname.replace(/^\/o\//, '');
-      const encoded = encodeURIComponent(rawPath);
-      const params = new URLSearchParams(uo.search);
-      if (!params.has('alt')) params.set('alt', 'media');
-      return `https://firebasestorage.googleapis.com/v0/b/${bucket}/o/${encoded}?${params.toString()}`;
-    }
-  } catch (error) {
-    console.warn('URL parsing failed:', error);
-  }
+	try {
+		const uo = new URL(url);
 
-  return url;
+		// ✅ FIX: Convert old appspot.com URLs to firebasestorage.app
+		if (uo.hostname === 'firebasestorage.googleapis.com' && uo.pathname.startsWith('/v0/b/')) {
+			// Extract bucket name from path
+			const pathParts = uo.pathname.split('/');
+			const bucketName = pathParts[3]; // /v0/b/{bucket}/o/...
+
+			// If it's the old appspot.com format, convert to firebasestorage.app
+			if (bucketName.endsWith('.appspot.com')) {
+				const newBucket = bucketName.replace('.appspot.com', '.firebasestorage.app');
+				uo.pathname = uo.pathname.replace(bucketName, newBucket);
+				return uo.toString();
+			}
+
+			return url; // Already correct format
+		}
+
+		// Handle gs:// URLs
+		if (url.startsWith('gs://')) {
+			const without = url.slice(5);
+			const i = without.indexOf('/');
+			const bucket = i === -1 ? without : without.slice(0, i);
+			const objectPath = i === -1 ? '' : without.slice(i + 1);
+
+			// Use the correct firebasestorage.app domain
+			const correctBucket = bucket.endsWith('.appspot.com')
+				? bucket.replace('.appspot.com', '.firebasestorage.app')
+				: bucket;
+
+			const encoded = encodeURIComponent(objectPath);
+			return `https://firebasestorage.googleapis.com/v0/b/${correctBucket}/o/${encoded}?alt=media`;
+		}
+
+		// Handle .firebasestorage.app URLs (correct format)
+		if (uo.hostname.endsWith('.firebasestorage.app')) {
+			const bucket = uo.hostname;
+			const rawPath = uo.pathname.replace(/^\/o\//, '');
+			const encoded = encodeURIComponent(rawPath);
+			const params = new URLSearchParams(uo.search);
+			if (!params.has('alt')) params.set('alt', 'media');
+			return `https://firebasestorage.googleapis.com/v0/b/${bucket}/o/${encoded}?${params.toString()}`;
+		}
+	} catch (error) {
+		console.warn('URL parsing failed:', error);
+	}
+
+	return url;
 }

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -1,37 +1,37 @@
 // src/routes/blog/[slug]/+page.server.ts
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import { normalizeFirebaseUrl } from '$lib/services/imageLoading';
+import { normalizeFirebaseUrl } from '$lib/utils/urls';
 
 export const load: PageServerLoad = async ({ params }) => {
-  try {
-    // CRITICAL FIX: Dynamic imports to prevent build issues
-    const [{ getPostBySlug }, { mdToHtml }] = await Promise.all([
-      import('$lib/server/posts'),
-      import('$lib/server/markdown')
-    ]);
-    
-    const post = await getPostBySlug(params.slug);
-    
-    if (!post || post.status !== 'published') {
-      throw error(404, 'Post not found');
-    }
+	try {
+		// CRITICAL FIX: Dynamic imports to prevent build issues
+		const [{ getPostBySlug }, { mdToHtml }] = await Promise.all([
+			import('$lib/server/posts'),
+			import('$lib/server/markdown')
+		]);
 
-    return {
-      post: {
-        ...post,
-        heroImage: normalizeFirebaseUrl(post.heroImage) ?? undefined,
-        contentHtml: await mdToHtml(post.contentMarkdown ?? '')
-      }
-    };
-  } catch (err) {
-    console.error('[blog/slug] Load error:', params.slug, err);
-    
-    // Re-throw SvelteKit errors
-    if (err && typeof err === 'object' && 'status' in err) {
-      throw err;
-    }
-    
-    throw error(500, 'Failed to load blog post');
-  }
+		const post = await getPostBySlug(params.slug);
+
+		if (!post || post.status !== 'published') {
+			throw error(404, 'Post not found');
+		}
+
+		return {
+			post: {
+				...post,
+				heroImage: normalizeFirebaseUrl(post.heroImage) ?? undefined,
+				contentHtml: await mdToHtml(post.contentMarkdown ?? '')
+			}
+		};
+	} catch (err) {
+		console.error('[blog/slug] Load error:', params.slug, err);
+
+		// Re-throw SvelteKit errors
+		if (err && typeof err === 'object' && 'status' in err) {
+			throw err;
+		}
+
+		throw error(500, 'Failed to load blog post');
+	}
 };


### PR DESCRIPTION
## Summary
- centralize Firebase URL normalization in `urls.ts`
- re-export normalization helper from image service and update server page import

## Testing
- `npm run format` *(fails: tag_invalid_name in src/lib/components/Hero.svelte)*
- `npm run check` *(fails: Property 'createTransporter' does not exist, Property 'items' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b92f919244832bbb7de81561e18717