### PR TITLE
Fix nodemailer transport setup

### DIFF
--- a/src/routes/contact/+page.server.ts
+++ b/src/routes/contact/+page.server.ts
@@ -55,8 +55,8 @@ export const actions: Actions = {
     try {
       // CRITICAL FIX: Import nodemailer inside the action to prevent build issues
       const nodemailer = await import('nodemailer');
-      
-      const transporter = nodemailer.createTransporter({
+
+      const transporter = nodemailer.default.createTransport({
         service: 'gmail',
         auth: {
           user: gmailUser,


### PR DESCRIPTION
## Summary
- fix contact form transporter to use nodemailer.createTransport

## Testing
- `npm ls @types/nodemailer`
- `npm run check` (fails: Object literal may only specify known properties, '"featured"' does not exist in type '{ book: Book; }'.)


------
https://chatgpt.com/codex/tasks/task_e_68b92f94bb10832bbae82da9f6a28751