### PR TITLE
refactor: use imageLoading service for image constants

### DIFF
--- a/src/lib/components/GenreIcon.svelte
+++ b/src/lib/components/GenreIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FIREBASE_IMAGES } from '$lib/utils/image';
+  import { FIREBASE_IMAGES } from '$lib/services/imageLoading';
   
   export let genre: 'faith' | 'epic' = 'faith';
   export let size: 'sm' | 'md' | 'lg' = 'md';

--- a/src/lib/data/books.ts
+++ b/src/lib/data/books.ts
@@ -1,6 +1,6 @@
 // src/lib/data/books.ts
 import type { Book } from '../types.js';
-import { IMAGES } from '$lib/utils/image';
+import { IMAGES } from '$lib/services/imageLoading';
 
 export const books: Book[] = [
   {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-  // FIX: your util file is singular: src/lib/utils/image.ts
-  // and should export IMAGES (or adjust as needed)
-  import { IMAGES } from '$lib/utils/image';
+  import { IMAGES } from '$lib/services/imageLoading';
   import { progressiveImage } from '$lib/actions/progressiveImage';
   import { FALLBACK_IMAGES } from '$lib/services/imageLoading';
 </script>


### PR DESCRIPTION
## Summary
- update book data to import IMAGES from imageLoading service
- switch GenreIcon and about page to imageLoading service for image constants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e7ccf9f4832bb8acd046e3ceaf96