### PR TITLE
Preserve firebasestorage.app URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
 		"lint": "prettier --plugin-search-dir . --check .",
 		"format": "prettier --plugin-search-dir . --write .",
 		"type-check": "tsc --noEmit",
-		"build:check": "npm run check && npm run build",
-		"clean": "rm -rf .svelte-kit build dist",
-		"postinstall": "svelte-kit sync"
-	},
+                "build:check": "npm run check && npm run build",
+                "clean": "rm -rf .svelte-kit build dist",
+                "postinstall": "svelte-kit sync",
+                "test": "vitest run"
+        },
 	"engines": {
 		"node": ">=18.13"
 	},
@@ -35,11 +36,12 @@
 		"prettier": "^3.3.3",
 		"prettier-plugin-svelte": "^3.2.6",
 		"svelte": "^5.38.6",
-		"svelte-check": "^4.0.4",
-		"tailwindcss": "^3.4.17",
-		"typescript": "^5.6.3",
-		"vite": "^7.1.4"
-	},
+                "svelte-check": "^4.0.4",
+                "tailwindcss": "^3.4.17",
+                "typescript": "^5.6.3",
+                "vite": "^7.1.4",
+                "vitest": "^2.1.3"
+        },
 	"dependencies": {
 		"marked": "^16.2.1",
 		"mongodb": "^6.19.0",

--- a/src/lib/utils/urls.test.ts
+++ b/src/lib/utils/urls.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFirebaseUrl } from './urls';
+
+describe('normalizeFirebaseUrl', () => {
+  it('keeps .firebasestorage.app URLs and adds alt=media', () => {
+    const input =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket.firebasestorage.app/o/file.txt';
+    const result = normalizeFirebaseUrl(input);
+
+    expect(result).toBeTruthy();
+    const url = new URL(result!);
+    expect(url.searchParams.get('alt')).toBe('media');
+    expect(result).toContain('test-bucket.firebasestorage.app');
+    expect(result).not.toContain('appspot.com');
+  });
+
+  it('adds alt=media to .appspot.com URLs', () => {
+    const input =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket.appspot.com/o/file.txt';
+    const result = normalizeFirebaseUrl(input);
+
+    expect(result).toBeTruthy();
+    const url = new URL(result!);
+    expect(url.searchParams.get('alt')).toBe('media');
+    expect(result).toContain('test-bucket.appspot.com');
+  });
+});
+

--- a/src/lib/utils/urls.ts
+++ b/src/lib/utils/urls.ts
@@ -3,32 +3,28 @@
  * Normalize Firebase Storage URLs for consistent access
  */
 export function normalizeFirebaseUrl(url?: string | null): string | null {
-	if (!url || typeof url !== 'string') return null;
-	
-	try {
-	  // Already normalized or not a Firebase URL
-	  if (!url.includes('firebase')) return url;
-	  
-	  // Convert firebasestorage.app to appspot.com (more reliable)
-	  let normalized = url.replace(
-		/https:\/\/firebasestorage\.googleapis\.com\/v0\/b\/([^\/]+)\.firebasestorage\.app/,
-		'https://firebasestorage.googleapis.com/v0/b/$1.appspot.com'
-	  );
-	  
-	  // Ensure alt=media parameter is present for direct access
-	  if (normalized.includes('firebasestorage.googleapis.com')) {
-		const urlObj = new URL(normalized);
-		if (!urlObj.searchParams.has('alt')) {
-		  urlObj.searchParams.set('alt', 'media');
-		  normalized = urlObj.toString();
-		}
-	  }
-	  
-	  return normalized;
-	} catch (error) {
-	  console.warn('[normalizeFirebaseUrl] Invalid URL:', url, error);
-	  return url; // Return original if parsing fails
-	}
+        if (!url || typeof url !== 'string') return null;
+
+        try {
+          // Already normalized or not a Firebase URL
+          if (!url.includes('firebase')) return url;
+
+          let normalized = url;
+
+          // Ensure alt=media parameter is present for direct access
+          if (normalized.includes('firebasestorage.googleapis.com')) {
+                const urlObj = new URL(normalized);
+                if (!urlObj.searchParams.has('alt')) {
+                  urlObj.searchParams.set('alt', 'media');
+                  normalized = urlObj.toString();
+                }
+          }
+
+          return normalized;
+        } catch (error) {
+          console.warn('[normalizeFirebaseUrl] Invalid URL:', url, error);
+          return url; // Return original if parsing fails
+        }
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "types": ["svelte"]
+    "types": ["svelte", "vitest"]
   },
   "include": ["src/**/*", ".svelte-kit/**/*.d.ts"],
   "exclude": [


### PR DESCRIPTION
## Summary
- stop rewriting `*.firebasestorage.app` to `*.appspot.com` in `normalizeFirebaseUrl`
- still ensure `alt=media` query param is appended when missing
- cover `.firebasestorage.app` and `.appspot.com` cases with unit tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b9e923eb74832bb1b8541cb8fa9c12