### PR TITLE
refactor: centralize genre icons

### DIFF
--- a/src/lib/config/genre-icons.ts
+++ b/src/lib/config/genre-icons.ts
@@ -1,8 +1,12 @@
-// src/lib/config/genre-icons.ts
+import { FIREBASE_IMAGES } from '$lib/services/imageLoading';
+import { normalizeFirebaseUrl } from '$lib/utils/urls';
+
+const SCI_FI_ICON = normalizeFirebaseUrl('https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/sci-fi-icon.png?alt=media&token=b26abe91-c816-41e4-ab95-086080369bd1')!;
+const DEFAULT_ICON = normalizeFirebaseUrl('https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/default-icon.png?alt=media')!;
+
 export const GENRE_ICON_URLS: Record<string, string> = {
-    faith: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/faith-icon.png?alt=media&token=PUT_YOUR_TOKEN_HERE',
-    epic: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/epic-icon.png?alt=media&token=PUT_YOUR_TOKEN_HERE',
-    'sci-fi': 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/sci-fi-icon.png?alt=media&token=b26abe91-c816-41e4-ab95-086080369bd1',
-    default: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/default-icon.png?alt=media&token=PUT_YOUR_TOKEN_HERE'
-  };
-  
+  faith: FIREBASE_IMAGES.ICONS.CHRISTIAN_FICTION,
+  epic: FIREBASE_IMAGES.ICONS.EPIC_FANTASY,
+  'sci-fi': SCI_FI_ICON,
+  default: DEFAULT_ICON
+};


### PR DESCRIPTION
## Summary
- import central FIREBASE_IMAGES map for genre icons
- normalize sci-fi and default icons, removing token placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b9e9ea295c832ba0522414dc86e0cc