### PR TITLE
refactor navigation logo to centralized firebase image

### DIFF
--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
   import { afterNavigate } from '$app/navigation';
   import { onMount } from 'svelte';
+  import { FIREBASE_IMAGES } from '$lib/services/imageLoading';
 
   let mobileMenuOpen = false;
 
@@ -44,7 +45,7 @@
     <!-- Left: Brand -->
     <a href="/" class="flex items-center gap-3 min-w-0" aria-label="Charles Boswell - Home">
       <img
-        src="https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f"
+        src={FIREBASE_IMAGES.ICONS.SIGNATURE_LOGO}
         alt="Charles Boswell signature logo"
         width="56"
         height="56"


### PR DESCRIPTION
## Summary
- source navigation logo from FIREBASE_IMAGES service instead of hardcoding

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68b9ea3fe260832ba8adbaa4054c6327