### PR TITLE
chore: update firebase storage bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ MONGODB_URI="mongodb+srv://<username>:<password>@cluster0.mongodb.net/?retryWrit
 MONGODB_DB="author_site"
 
 # Optional: Firebase bucket (for images)
-FIREBASE_BUCKET="endless-fire-467204-n2.appspot.com"
+FIREBASE_BUCKET="endless-fire-467204-n2.firebasestorage.app"
 ```
 
 ---

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -16,7 +16,7 @@ function getEnvVar(key: string, defaultValue?: string): string | undefined {
   export const ENV = {
     MONGODB_URI: getEnvVar('MONGODB_URI'),
     MONGODB_DB: getEnvVar('MONGODB_DB', 'author_site'),
-    FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.appspot.com'),
+    FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.firebasestorage.app'),
     PUBLIC_SITE_URL: getEnvVar('PUBLIC_SITE_URL', 'http://localhost:3000'),
   } as const;
   

--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -8,23 +8,23 @@ import { createImageFallback } from '$lib/utils/image';
  */
 export const FIREBASE_IMAGES = {
   BOOKS: {
-    FAITH_IN_A_FIRESTORM: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3",
-    CONVICTION_IN_A_FLOOD: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Conviction_in_a_Flood%20Cover.png?alt=media&token=0e9ea64f-f71c-427e-a63e-dfdc301a60c1",
-    HURRICANE_EVE: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Hurricane_Eve%20Cover.png?alt=media&token=547854ac-b00e-411a-b5e5-e15995b01334",
-    THE_FAITH_OF_THE_HUNTER: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/TheFaithoftheHuntercover.png?alt=media&token=ac09e3b1-7cee-4df3-bc9e-dcbcf14a482f",
-    HEART_OF_THE_STORM: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Heart_of_the_Storm_Elf_and_Wolf.png?alt=media&token=5376fbb7-b0e4-4595-abc8-6ec96be68005",
-    SYMBIOGENESIS: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Symbiogenesis.png?alt=media&token=f9a763d8-bc7e-49d5-8bb2-afe2596ac023"
+    FAITH_IN_A_FIRESTORM: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3",
+    CONVICTION_IN_A_FLOOD: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Conviction_in_a_Flood%20Cover.png?alt=media&token=0e9ea64f-f71c-427e-a63e-dfdc301a60c1",
+    HURRICANE_EVE: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Hurricane_Eve%20Cover.png?alt=media&token=547854ac-b00e-411a-b5e5-e15995b01334",
+    THE_FAITH_OF_THE_HUNTER: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/TheFaithoftheHuntercover.png?alt=media&token=ac09e3b1-7cee-4df3-bc9e-dcbcf14a482f",
+    HEART_OF_THE_STORM: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Heart_of_the_Storm_Elf_and_Wolf.png?alt=media&token=5376fbb7-b0e4-4595-abc8-6ec96be68005",
+    SYMBIOGENESIS: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Symbiogenesis.png?alt=media&token=f9a763d8-bc7e-49d5-8bb2-afe2596ac023"
   },
   AUTHOR: {
-    PORTRAIT: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/CharlesBoswell.jpg?alt=media&token=1ba4211f-b06c-49c3-9ef9-96e75fccc8e0",
-    FIREFIGHTER: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/CharlesBosewll_USFS.jpg?alt=media&token=46388a4c-27d2-4da6-9ad3-9d4c9b279e05",
-    NAVY: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Navy1993.JPG?alt=media&token=c1be8697-f87e-404b-b6df-8d3d856f2140",
-    AUGUST_25: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58"
+    PORTRAIT: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBoswell.jpg?alt=media&token=1ba4211f-b06c-49c3-9ef9-96e75fccc8e0",
+    FIREFIGHTER: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/CharlesBosewll_USFS.jpg?alt=media&token=46388a4c-27d2-4da6-9ad3-9d4c9b279e05",
+    NAVY: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Navy1993.JPG?alt=media&token=c1be8697-f87e-404b-b6df-8d3d856f2140",
+    AUGUST_25: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/August25.png?alt=media&token=ae2aa914-5e2e-4519-9749-077037b54e58"
   },
   ICONS: {
-    SIGNATURE_LOGO: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f",
-    CHRISTIAN_FICTION: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/ChristianFiction.png?alt=media&token=6f8f6512-0818-44aa-8fd6-2c29b80c570d",
-    EPIC_FANTASY: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/EpicFantasy.png?alt=media&token=3534891a-927d-4a4b-aa82-911ea6e03025"
+    SIGNATURE_LOGO: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Signaturelogo.png?alt=media&token=11b771f1-789b-426a-b9e0-b24caf98150f",
+    CHRISTIAN_FICTION: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/ChristianFiction.png?alt=media&token=6f8f6512-0818-44aa-8fd6-2c29b80c570d",
+    EPIC_FANTASY: "https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/EpicFantasy.png?alt=media&token=3534891a-927d-4a4b-aa82-911ea6e03025"
   }
 } as const;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
     id: 'faith-in-a-firestorm',
     title: 'Faith in a Firestorm',
     description: "A faith-forward wildfire drama inspired by 16 years on the line—courage, family, and grace when everything burns.",
-    cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3',
+    cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Faith_in_a_FireStorm.png?alt=media&token=33d6bfa5-d3ff-4a4c-8d9b-a185282cacc3',
     genre: 'faith',  // Explicit typing
     status: 'published'
   };
@@ -25,7 +25,7 @@
       id: 'conviction-in-a-flood',
       title: 'Conviction in a Flood',
       description: 'A companion novel exploring faith and resilience when rising waters test a community\'s resolve.',
-      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Conviction_in_a_Flood%20Cover.png?alt=media&token=0e9ea64f-f71c-427e-a63e-dfdc301a60c1',
+      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Conviction_in_a_Flood%20Cover.png?alt=media&token=0e9ea64f-f71c-427e-a63e-dfdc301a60c1',
       genre: 'faith',
       status: 'coming-soon',
       publishDate: '2026-03-15'
@@ -34,7 +34,7 @@
       id: 'hurricane-eve',
       title: 'Hurricane Eve',
       description: 'The third installment of the Faith & Calamity series—a storm that shatters records and faith itself.',
-      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/Hurricane_Eve%20Cover.png?alt=media&token=547854ac-b00e-411a-b5e5-e15995b01334',
+      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/Hurricane_Eve%20Cover.png?alt=media&token=547854ac-b00e-411a-b5e5-e15995b01334',
       genre: 'faith',
       status: 'coming-soon',
       publishDate: '2026-09-15'
@@ -43,7 +43,7 @@
       id: 'faith-of-the-hunter',
       title: 'The Faith of the Hunter',
       description: 'David Paczer, thrust into a brutal medieval world where faith and survival collide.',
-      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.appspot.com/o/TheFaithoftheHuntercover.png?alt=media&token=ac09e3b1-7cee-4df3-bc9e-dcbcf14a482f',
+      cover: 'https://firebasestorage.googleapis.com/v0/b/endless-fire-467204-n2.firebasestorage.app/o/TheFaithoftheHuntercover.png?alt=media&token=ac09e3b1-7cee-4df3-bc9e-dcbcf14a482f',
       genre: 'epic',
       status: 'coming-soon',
       publishDate: '2026-09-01'


### PR DESCRIPTION
## Summary
- switch cover image URLs to `endless-fire-467204-n2.firebasestorage.app`
- update image service constants and env default bucket

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find prettier-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1e65978832baac12af688a8d959