### PR TITLE
Use unicode-safe base64 for image fallbacks

### DIFF
--- a/src/lib/components/ReliableImage.svelte
+++ b/src/lib/components/ReliableImage.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { normalizeFirebaseUrl } from '$lib/utils/urls';
+  import { toBase64UnicodeSafe } from '$lib/utils/image';
   import { browser } from '$app/environment';
   
   // Props
@@ -30,7 +31,7 @@
             font-family="Arial, sans-serif" font-size="24" fill="#6b7280">${text}</text>
     </svg>`;
     
-    return `data:image/svg+xml;base64,${btoa(svg)}`;
+    return `data:image/svg+xml;base64,${toBase64UnicodeSafe(svg)}`;
   }
   
   // Reactive statements

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -4,7 +4,7 @@ import { normalizeFirebaseUrl } from '$lib/utils/urls';
 const isBrowser = typeof window !== 'undefined';
 
 /** Unicode-safe base64 for SVG, works in SSR and browser */
-function toBase64UnicodeSafe(svg: string): string {
+export function toBase64UnicodeSafe(svg: string): string {
   if (isBrowser && typeof btoa === 'function') {
     return btoa(unescape(encodeURIComponent(svg)));
   }


### PR DESCRIPTION
## Summary
- export `toBase64UnicodeSafe` helper from image utilities
- apply unicode-safe base64 encoding to fallback SVGs in `ReliableImage`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_68b9f1bbbfc4832b829134975792d494