### PR TITLE
test: add ReliableImage fallback test

### DIFF
--- a/src/lib/components/ReliableImage.test.ts
+++ b/src/lib/components/ReliableImage.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import ReliableImage from './ReliableImage.svelte';
+
+describe('ReliableImage', () => {
+  it('falls back to data URI when src is null', () => {
+    let result: { html: string } | undefined;
+    expect(() => {
+      result = ReliableImage.render({ src: null, alt: 'test' });
+    }).not.toThrow();
+    expect(result!.html).toContain('data:image/svg+xml;base64');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for ReliableImage fallback to ensure render handles null src and embeds data URI

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1bf15ec832ba7ef0f49f597cee5