### PR TITLE
docs: update Firebase bucket reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ MONGODB_URI="mongodb+srv://<username>:<password>@cluster0.mongodb.net/?retryWrit
 MONGODB_DB="author_site"
 
 # Optional: Firebase bucket (for images)
-FIREBASE_BUCKET="endless-fire-467204-n2.appspot.com"
+FIREBASE_BUCKET="endless-fire-467204-n2.firebasestorage.app"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- correct Firebase Storage bucket domain in README environment variable example

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1d402fc832bae0ab46871cb2e4b