### PR TITLE
chore: update firebase bucket domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ MONGODB_URI="mongodb+srv://<username>:<password>@cluster0.mongodb.net/?retryWrit
 MONGODB_DB="author_site"
 
 # Optional: Firebase bucket (for images)
-FIREBASE_BUCKET="endless-fire-467204-n2.appspot.com"
+FIREBASE_BUCKET="endless-fire-467204-n2.firebasestorage.app"
 ```
 
 ---

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -16,15 +16,15 @@ function getEnvVar(key: string, defaultValue?: string): string | undefined {
   export const ENV = {
     MONGODB_URI: getEnvVar('MONGODB_URI'),
     MONGODB_DB: getEnvVar('MONGODB_DB', 'author_site'),
-    FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.appspot.com'),
+    FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.firebasestorage.app'),
     PUBLIC_SITE_URL: getEnvVar('PUBLIC_SITE_URL', 'http://localhost:3000'),
   } as const;
-  
+
   // Validate required environment variables
   export function validateEnv(): void {
     const required = ['MONGODB_URI'] as const;
     const missing = required.filter(key => !ENV[key]);
-    
+
     if (missing.length > 0) {
       throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
     }

--- a/src/lib/utils/urls.test.ts
+++ b/src/lib/utils/urls.test.ts
@@ -24,5 +24,16 @@ describe('normalizeFirebaseUrl', () => {
     expect(url.searchParams.get('alt')).toBe('media');
     expect(result).toContain('test-bucket.appspot.com');
   });
+
+  it('preserves existing tokens in the URL', () => {
+    const input =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket.appspot.com/o/file.txt?alt=media&token=123';
+    const result = normalizeFirebaseUrl(input);
+
+    expect(result).toBeTruthy();
+    const url = new URL(result!);
+    expect(url.searchParams.get('alt')).toBe('media');
+    expect(url.searchParams.get('token')).toBe('123');
+  });
 });
 


### PR DESCRIPTION
## Summary
- update default Firebase bucket to use firebasestorage.app domain
- document new bucket domain
- test that token query params are preserved when normalizing Firebase URLs

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1df5478832ba3c7211ed5525cc1