### PR TITLE
refactor: log homepage data reactively

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,15 +2,20 @@
 <script lang="ts">
   import ReliableImage from '$lib/components/ReliableImage.svelte';
   import { FIREBASE_IMAGES } from '$lib/services/imageLoading';
-  
+
   export let data;
   
+  let featured;
+  let upcoming = [];
+
   // Test data if none from server
   $: featured = data?.featured || null;
   $: upcoming = data?.upcoming || [];
-  
-  console.log('[Homepage] Featured:', featured);
-  console.log('[Homepage] Upcoming:', upcoming.length);
+
+  $: {
+    console.log('[Homepage] Featured:', featured);
+    console.log('[Homepage] Upcoming:', upcoming.length);
+  }
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- ensure upcoming list initialized to avoid undefined access
- move homepage logging into a reactive block for proper timing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f880afa0832b9d0605d14ed5d563