### PR TITLE
Add homepage placeholder data when database empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ export interface PostDoc {
 
   * Collections: `books`, `posts`
   * Documents follow the interfaces above for type safety and consistency.
+  * If no featured or upcoming books exist, the homepage loader returns a default featured book and sample upcoming titles from `FIREBASE_IMAGES` so the page still renders.
 
 * **Image Handling**:
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,6 +2,7 @@
 import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db';
 import { normalizeFirebaseUrl } from '$lib/utils/urls';
+import { FIREBASE_IMAGES } from '$lib/services/imageLoading';
 
 type BookDoc = {
   id: string;
@@ -70,6 +71,39 @@ export const load: PageServerLoad = async () => {
       .sort({ publishDate: -1 }) // newest first if present
       .limit(12)
       .toArray();
+
+    if (!featuredDoc && upcoming.length === 0) {
+      console.warn('[+page.server] No books found, returning placeholder data');
+
+      const featured = {
+        id: 'faith-in-a-firestorm',
+        title: 'Faith in a Firestorm',
+        description:
+          'A faith-forward wildfire drama inspired by 16 years on the line—courage, family, and grace when everything burns.',
+        cover: normalizeFirebaseUrl(FIREBASE_IMAGES.BOOKS.FAITH_IN_A_FIRESTORM),
+        genre: 'faith',
+        status: 'upcoming'
+      } as const;
+
+      const upcomingSample = [
+        {
+          id: 'conviction-in-a-flood',
+          title: 'Conviction in a Flood',
+          cover: normalizeFirebaseUrl(FIREBASE_IMAGES.BOOKS.CONVICTION_IN_A_FLOOD),
+          genre: 'faith',
+          status: 'upcoming'
+        },
+        {
+          id: 'hurricane-eve',
+          title: 'Hurricane Eve',
+          cover: normalizeFirebaseUrl(FIREBASE_IMAGES.BOOKS.HURRICANE_EVE),
+          genre: 'epic',
+          status: 'upcoming'
+        }
+      ];
+
+      return { featured, upcoming: upcomingSample };
+    }
 
     // 3) If no featured is set, fall back to the most recent from upcoming
     const effectiveFeatured = featuredDoc ?? upcoming[0] ?? null;


### PR DESCRIPTION
## Summary
- Serve a default featured book and sample upcoming titles when MongoDB has no records
- Note placeholder behaviour in README so developers know the homepage still renders without DB data

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_68b9fafbc100832bbf3ebfc4a04e35a3