### PR TITLE
Normalize Firebase Storage bucket URLs

### DIFF
--- a/src/lib/utils/urls.test.ts
+++ b/src/lib/utils/urls.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { normalizeFirebaseUrl } from './urls';
 
 describe('normalizeFirebaseUrl', () => {
-  it('keeps .firebasestorage.app URLs and adds alt=media', () => {
+  it('rewrites .firebasestorage.app buckets to .appspot.com and adds alt=media', () => {
     const input =
       'https://firebasestorage.googleapis.com/v0/b/test-bucket.firebasestorage.app/o/file.txt';
     const result = normalizeFirebaseUrl(input);
@@ -10,8 +10,20 @@ describe('normalizeFirebaseUrl', () => {
     expect(result).toBeTruthy();
     const url = new URL(result!);
     expect(url.searchParams.get('alt')).toBe('media');
-    expect(result).toContain('test-bucket.firebasestorage.app');
-    expect(result).not.toContain('appspot.com');
+    expect(result).toContain('test-bucket.appspot.com');
+    expect(result).not.toContain('firebasestorage.app');
+  });
+
+  it('rewrites malformed bucket even when alt is already present', () => {
+    const input =
+      'https://firebasestorage.googleapis.com/v0/b/another-bucket.firebasestorage.app/o/file.txt?alt=media';
+    const result = normalizeFirebaseUrl(input);
+
+    expect(result).toBeTruthy();
+    const url = new URL(result!);
+    expect(url.searchParams.get('alt')).toBe('media');
+    expect(result).toContain('another-bucket.appspot.com');
+    expect(result).not.toContain('firebasestorage.app');
   });
 
   it('adds alt=media to .appspot.com URLs', () => {

--- a/src/lib/utils/urls.ts
+++ b/src/lib/utils/urls.ts
@@ -16,8 +16,19 @@ export function normalizeFirebaseUrl(url?: string | null): string | null {
                 const urlObj = new URL(normalized);
                 if (!urlObj.searchParams.has('alt')) {
                   urlObj.searchParams.set('alt', 'media');
-                  normalized = urlObj.toString();
                 }
+
+                // Some buckets incorrectly end with .firebasestorage.app
+                const bucketMatch = urlObj.pathname.match(/\/b\/([^\/]+)/);
+                if (bucketMatch) {
+                  const bucket = bucketMatch[1];
+                  if (bucket.endsWith('.firebasestorage.app')) {
+                        const fixedBucket = bucket.replace('.firebasestorage.app', '.appspot.com');
+                        urlObj.pathname = urlObj.pathname.replace(bucket, fixedBucket);
+                  }
+                }
+
+                normalized = urlObj.toString();
           }
 
           return normalized;


### PR DESCRIPTION
## Summary
- rewrite malformed `.firebasestorage.app` buckets to `.appspot.com`
- cover bucket rewriting with additional URL utility tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fafa8928832b84ded4b8177201f5