### PR TITLE
Guard ReliableImage logic with browser checks

### DIFF
--- a/src/lib/components/ReliableImage.svelte
+++ b/src/lib/components/ReliableImage.svelte
@@ -39,7 +39,7 @@
   $: fallbackSrc = createFallback(fallbackType);
   
   // Load image when src changes
-  $: if (cleanSrc && cleanSrc !== currentSrc) {
+  $: if (browser && cleanSrc && cleanSrc !== currentSrc) {
     loadImage(cleanSrc);
   }
   
@@ -96,10 +96,12 @@
   }
 
   onMount(() => {
-    if (cleanSrc) {
-      loadImage(cleanSrc);
-    } else {
-      handleError();
+    if (browser) {
+      if (cleanSrc) {
+        loadImage(cleanSrc);
+      } else {
+        handleError();
+      }
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- Only call `loadImage` when running in the browser and the source changes
- Gate `onMount` image loading behind a browser check

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_68b9fe6641b0832b89995938533cb4bb