### PR TITLE
chore: add image load warnings

### DIFF
--- a/src/lib/components/ReliableImage.svelte
+++ b/src/lib/components/ReliableImage.svelte
@@ -82,13 +82,12 @@
 
     img.src = url;
   }
-  
+
   function handleError() {
+    console.warn('[ReliableImage] Failed to load', currentSrc);
     isLoading = false;
     hasError = true;
-    if (imgElement) {
-      imgElement.src = fallbackSrc;
-    }
+    if (imgElement) imgElement.src = fallbackSrc;
   }
 
   function handleImgError() {

--- a/src/lib/services/imageLoading.ts
+++ b/src/lib/services/imageLoading.ts
@@ -61,6 +61,8 @@ class ImageLoadingService {
       const result = await loadPromise;
       if (result) {
         this.loadedImages.add(normalizedUrl);
+      } else {
+        console.warn('[ImageLoadingService] Failed to load', normalizedUrl);
       }
       return result;
     } catch (error) {
@@ -81,6 +83,7 @@ class ImageLoadingService {
       // Timeout to prevent hanging
       const timeout = setTimeout(() => {
         img.onload = img.onerror = null;
+        console.warn('[ImageLoadingService] Failed to load', src);
         resolve(null);
       }, 10000);
 
@@ -91,6 +94,7 @@ class ImageLoadingService {
 
       img.onerror = () => {
         clearTimeout(timeout);
+        console.warn('[ImageLoadingService] Failed to load', src);
         resolve(null);
       };
 

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -82,7 +82,11 @@ class ProgressiveImageLoader {
     const p = (async () => {
       try {
         const result = await preloadImage(key);
-        if (result) this.loadedImages.add(key);
+        if (result) {
+          this.loadedImages.add(key);
+        } else {
+          console.warn('[imageLoader] Failed to load', key);
+        }
         return result;
       } catch (error) {
         console.warn(`Image loading failed for: ${key}`, error);


### PR DESCRIPTION
## Summary
- warn with current image source when ReliableImage fails to load
- log failed image URLs in utils image loader
- add warnings in image loading service when image resolves null

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find prettier-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fe5bae64832b9b21c0238c855c80