### PR TITLE
Use resolveCover for hero cover images

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,7 +1,7 @@
 <!-- src/lib/components/Hero.svelte - FIXED VERSION -->
 <script lang="ts">
-  import { createImageFallback } from '$lib/utils/image';
-  import { normalizeFirebaseUrl } from '$lib/utils/urls';
+  import { onMount } from 'svelte';
+  import { createImageFallback, resolveCover } from '$lib/utils/image';
 
   export let title: string;
   export let subtitle: string;
@@ -9,6 +9,12 @@
   export let ctaText: string;
   export let genre: 'faith' | 'epic' | 'sci-fi' | null | undefined = null;
   export let bookCover: string | null | undefined = null;
+
+  let coverUrl: string | null = null;
+
+  onMount(async () => {
+    coverUrl = await resolveCover(bookCover);
+  });
 
   // Normalize genre so we always have a safe value
   $: safeGenre =
@@ -34,9 +40,6 @@
       ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700'
       : 'bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700';
 
-  // Normalize Firebase cover URLs (adds alt=media and returns the original domain)
-  $: coverSrc = bookCover ? normalizeFirebaseUrl(bookCover) : null;
-
   function dimOrFallback(e: Event) {
     const img = e.currentTarget as HTMLImageElement;
     if (!img.dataset._logged) {
@@ -50,10 +53,10 @@
 
 <section class={`relative text-white py-20 overflow-hidden ${gradientClass}`}>
   <div class="max-w-7xl mx-auto px-4 flex flex-col md:flex-row items-center gap-8">
-    {#if coverSrc}
+    {#if bookCover}
       <div class="w-48 h-72 flex-shrink-0">
         <img
-          src={coverSrc}
+          src={coverUrl ?? createImageFallback('Cover Unavailable')}
           alt={`${title} cover`}
           class="w-full h-full object-cover rounded shadow-lg transition-opacity duration-300"
           on:error={dimOrFallback}
@@ -70,6 +73,6 @@
       >
         {ctaText}
       </a>
-    </div>
+  </div>
   </div>
 </section>

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -112,6 +112,14 @@ class ProgressiveImageLoader {
 export const imageLoader = new ProgressiveImageLoader();
 
 /**
+ * Resolve a book cover URL ensuring it is loaded successfully.
+ * Returns the URL if it loads, otherwise null.
+ */
+export function resolveCover(url?: string | null): Promise<string | null> {
+  return imageLoader.load(url);
+}
+
+/**
  * Batch preload with better error handling
  */
 export async function preloadImages(urls: (string | null | undefined)[]): Promise<{


### PR DESCRIPTION
## Summary
- load hero cover images with new `resolveCover` utility
- set `coverUrl` on mount and fall back to placeholder when unavailable
- expose `resolveCover` helper in image utilities

## Testing
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba049a0368832bb132b7b19ee312a5