### PR TITLE
Standardize project on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,16 @@ git clone git@github.com:Boswell-web/author-site.git
 cd author-site
 ```
 
-Install dependencies (Yarn preferred):
+Install dependencies:
 
 ```bash
-yarn install
-# or
 npm install
 ```
 
 Start the dev server:
 
 ```bash
-yarn dev
+npm run dev
 ```
 
 Open the site at **[http://localhost:5173](http://localhost:5173)**
@@ -195,7 +193,7 @@ export interface PostDoc {
    * Build with:
 
      ```bash
-     yarn build
+     npm run build
      netlify deploy --prod
      ```
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
-# netlify.toml
+# Netlify configuration (uses npm)
 [build]
   command = "npm run build"
   publish = "build"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"engines": {
 		"node": ">=18.13"
 	},
-	"packageManager": "yarn@1.22.22",
+        "packageManager": "npm@11.4.2",
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3",
 		"@sveltejs/adapter-netlify": "^5.2.3",


### PR DESCRIPTION
## Summary
- adopt npm as the project package manager
- update setup and deployment docs to use npm commands
- note npm usage in Netlify build configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Invalid command: build)*

------
https://chatgpt.com/codex/tasks/task_e_68bce5f5da4c832b874350b910e1f8e7