### PR TITLE
chore: simplify build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"sync": "svelte-kit sync",
-		"build": "svelte-kit sync && svelte-kit build",
+                "build": "svelte-kit build",
 		"preview": "svelte-kit preview"
 	},
 	"engines": {


### PR DESCRIPTION
## Summary
- remove redundant SvelteKit sync step from build script

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Invalid command: build)
- `npx netlify deploy --build` (fails: 403 Forbidden - GET https://registry.npmjs.org/netlify)


------
https://chatgpt.com/codex/tasks/task_e_68bce90c9d08832bae0b1b9a729cfe55