### PR TITLE
Remove invalid checkServerIdentity option in Mongo client

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -18,10 +18,9 @@ function required(name: string): string {
   return val;
 }
 
-// ✅ FIXED: Remove invalid checkServerIdentity option
 function createMongoClient(uri: string): MongoClient {
   console.log('[mongo] Creating client for Atlas cluster...');
-  
+
   return new MongoClient(uri, {
     serverApi: { 
       version: ServerApiVersion.v1, 
@@ -33,8 +32,7 @@ function createMongoClient(uri: string): MongoClient {
     socketTimeoutMS: 45_000,
     tls: true,
     retryWrites: true,
-    retryReads: true,
-    // ❌ REMOVED: checkServerIdentity: true, // This was invalid
+    retryReads: true
   });
 }
 


### PR DESCRIPTION
## Summary
- clean up Mongo client configuration to drop `checkServerIdentity` property, relying on default TLS hostname verification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c073479f70832bbb2fa050ccfe847f