### PR TITLE
Load environment variables early in hooks

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,9 @@
 // src/hooks.server.ts
+import { validateEnv } from '$lib/config/env';
 import type { Handle } from '@sveltejs/kit';
+
+// Ensure environment variables are loaded before anything else
+validateEnv();
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {


### PR DESCRIPTION
## Summary
- call `validateEnv` from `$lib/config/env` in `src/hooks.server.ts` so .env variables populate `process.env`

## Testing
- `npm test` *(fails: Missing script "test")*
- `MONGODB_URI='mongodb://localhost:27017' npm run build` *(fails: Rollup failed to resolve import "dotenv/config" in env.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0771487c8832bbdcb72d9768b073b