### PR TITLE
Call validateEnv during server init

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,9 @@
 // src/hooks.server.ts
 import type { Handle } from '@sveltejs/kit';
+import { validateEnv } from '$lib/config/env';
+
+// Fail fast if required environment variables are missing
+validateEnv();
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {


### PR DESCRIPTION
## Summary
- Validate environment variables during server startup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `MONGODB_URI='mongodb://example.com/test' npm run build` *(fails: Rollup failed to resolve import "dotenv/config" from src/lib/config/env.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0771a8c04832bafed3cb726313826