### PR TITLE
Ensure book cover URLs are fully qualified

### DIFF
--- a/src/lib/server/books.ts
+++ b/src/lib/server/books.ts
@@ -1,12 +1,13 @@
 // src/lib/server/books.ts
 import { getDb } from '$lib/server/db';
+import { buildBookCoverUrl } from '$lib/utils/firebase';
 import type { Book, BookDoc, BookStatus } from '$lib/types';
 
 // Re-export for convenience
 export type { BookDoc } from '$lib/types';
 
 function ensureCover(url?: string | null): string | null {
-  return url ?? null;
+  return url ? buildBookCoverUrl(url) : null;
 }
 
 function toIsoOrNull(d: unknown): string | null {


### PR DESCRIPTION
## Summary
- Build cover URLs using `buildBookCoverUrl` so book helpers return fully qualified image paths

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0791af4bc832bb1684cbb13808a24