### PR TITLE
Load env vars for MongoDB connection

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DB=author_site

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ Thumbs.db
 *:*Zone.Identifier
 
 # Env
-.env
+# .env
 .env.*
 !.env.example
 !.env.test
@@ -22,5 +22,3 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-.env
-.env.*

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
 // src/hooks.server.ts
+import '$lib/config/env';
 import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1,6 +1,8 @@
 // src/lib/server/db.ts - FIXED VERSION
 
-import { MongoClient, Db, ServerApiVersion } from 'mongodb';
+import '$lib/config/env';
+import { MongoClient, ServerApiVersion } from 'mongodb';
+import type { Db } from 'mongodb';
 import { dev } from '$app/environment';
 
 // Global connection management


### PR DESCRIPTION
## Summary
- add `.env` with MongoDB connection settings
- ensure environment variables load at startup via `$lib/config/env`
- stop ignoring `.env` in `.gitignore`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07be06228832b9ef4019b903c96ba