### PR TITLE
feat: report MongoDB hostname in health check

### DIFF
--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,17 +1,21 @@
 import { json } from '@sveltejs/kit';
 import { getDb, testConnection } from '$lib/server/db';
+import { ENV } from '$lib/config/env';
 
 export async function GET() {
   try {
     const isHealthy = await testConnection();
     const db = await getDb();
-    
+
     const collections = await db.listCollections().toArray();
-    
+
+    const uri = ENV.MONGODB_URI;
+    const cluster = uri ? new URL(uri).hostname : undefined;
+
     return json({
       status: 'ok',
       database: db.databaseName,
-      cluster: 'cluster0.njrpul0.mongodb.net',
+      cluster,
       healthy: isHealthy,
       collections: collections.map(c => c.name),
       timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- parse MongoDB connection URI via ENV and expose its hostname in health route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07ead5178832b9dc6914f77e543e0