### PR TITLE
Ensure required environment variables at server start

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,8 @@
 // src/hooks.server.ts
 import type { Handle } from '@sveltejs/kit';
+import validateEnv from './lib/config/env';
+
+validateEnv();
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {
@@ -13,3 +16,4 @@ export const handle: Handle = async ({ event, resolve }) => {
 export function handleError({ error }) {
   console.error('[HOOK] handleError:', error);
 }
+

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -1,26 +1,30 @@
 import 'dotenv/config';
-// Helper to get environment variable safely
+
+// Helper to get environment variables safely
 function getEnvVar(key: string, defaultValue?: string): string | undefined {
-    // Try different ways to access environment variables
-    if (typeof process !== 'undefined' && process.env) {
-      return process.env[key] || defaultValue;
-    }
-    return defaultValue;
+  // Try different ways to access environment variables
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[key] || defaultValue;
   }
-  
-  export const ENV = {
-    MONGODB_URI: getEnvVar('MONGODB_URI'),
-    MONGODB_DB: getEnvVar('MONGODB_DB', 'author_site'),
-    FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.firebasestorage.app'),
-    PUBLIC_SITE_URL: getEnvVar('PUBLIC_SITE_URL', 'http://localhost:3000'),
-  } as const;
+  return defaultValue;
+}
 
-  // Validate required environment variables
-  export function validateEnv(): void {
-    const required = ['MONGODB_URI'] as const;
-    const missing = required.filter(key => !ENV[key]);
+export const ENV = {
+  MONGODB_URI: getEnvVar('MONGODB_URI'),
+  MONGODB_DB: getEnvVar('MONGODB_DB', 'author_site'),
+  FIREBASE_BUCKET: getEnvVar('FIREBASE_BUCKET', 'endless-fire-467204-n2.firebasestorage.app'),
+  PUBLIC_SITE_URL: getEnvVar('PUBLIC_SITE_URL', 'http://localhost:3000'),
+} as const;
 
-    if (missing.length > 0) {
-      throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
-    }
+// Validate required environment variables
+export function validateEnv(): void {
+  const required = ['MONGODB_URI'] as const;
+  const missing = required.filter(key => !ENV[key]);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
   }
+}
+
+export default validateEnv;
+


### PR DESCRIPTION
## Summary
- expose `validateEnv` utility from env config
- enforce environment validation in server hooks to catch missing `MONGODB_URI`

## Testing
- `MONGODB_URI='mongodb://localhost:27017' npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c07eaf39bc832b84d7a8c73432e57b