### PR TITLE
feat: add mock collection count support

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -138,18 +138,22 @@ export async function getDb(): Promise<Db> {
     // Only fallback in development
     console.warn('[mongo] Development fallback - returning mock database');
     const emptyResult = { toArray: async () => [] };
-    
+    const findResult = {
+      sort: () => findResult,
+      skip: () => findResult,
+      limit: () => emptyResult,
+      toArray: async () => []
+    };
+
     return {
       collection: () => ({
-        find: () => ({
-          sort: () => ({ limit: () => emptyResult, toArray: async () => [] }),
-          limit: () => emptyResult,
-          toArray: async () => []
-        }),
+        find: () => findResult,
         findOne: async () => null,
         insertOne: async () => ({ insertedId: null }),
         updateOne: async () => ({ modifiedCount: 0 }),
-        deleteOne: async () => ({ deletedCount: 0 })
+        deleteOne: async () => ({ deletedCount: 0 }),
+        countDocuments: async () => 0,
+        estimatedDocumentCount: async () => 0
       }),
       command: async () => ({ ok: 1 }),
       listCollections: () => ({ toArray: async () => [] }),


### PR DESCRIPTION
## Summary
- mock collection now supports `countDocuments` and `estimatedDocumentCount`
- extend mock `find` chain with `skip` to avoid runtime errors when MongoDB is absent

## Testing
- `npm run build`
- `npm run dev` & `curl -s -o /tmp/blog.html -w "%{http_code}\n" http://localhost:3001/blog`


------
https://chatgpt.com/codex/tasks/task_e_68c080852a6c832b8b276c1e87501bde