### PR TITLE
refactor: centralize line clamp utility

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -238,7 +238,7 @@
     line-clamp: 2; /* Standard property for compatibility */
     overflow: hidden;
   }
-  .text-clamp-3 {
+  .line-clamp-3 {
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -175,11 +175,4 @@
   </section>
 {/if}
 
-<style>
-  .line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-</style>
+

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -281,7 +281,7 @@
 
               {#if post.excerpt}
                 <div class="prose prose-gray max-w-none mb-4">
-                  <p class="text-gray-700 leading-relaxed">{post.excerpt}</p>
+                  <p class="text-gray-700 leading-relaxed line-clamp-3">{post.excerpt}</p>
                 </div>
               {/if}
 
@@ -418,13 +418,3 @@
   </div>
 </div>
 
-<!-- Keep utility styles minimal; no Tailwind @apply here -->
-<style>
-  .blog-post-excerpt {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    line-clamp: 3;
-    overflow: hidden;
-  }
-</style>

--- a/src/routes/books/+page.svelte
+++ b/src/routes/books/+page.svelte
@@ -217,13 +217,3 @@
   {/if}
 </div>
 
-<style>
-  /* Custom line-clamp utility for description truncation */
-  .line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    line-clamp: 3;
-  }
-</style>


### PR DESCRIPTION
## Summary
- move `line-clamp-3` utility into `app.css`
- remove page-level style blocks and apply shared class across books, blog, and home pages

## Testing
- `npm test` *(fails: No test files found)*
- `npm run check` *(fails: svelte-check found 60 errors and 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c812e88832bb114a8ae0b337713