### PR TITLE
Fix dark mode selectors

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -66,8 +66,8 @@
     scroll-behavior: smooth;
   }
 
-  .dark html,
-  .dark body {
+  html.dark,
+  body.dark {
     background-color: var(--primary-50);
     color: var(--primary-700);
   }


### PR DESCRIPTION
## Summary
- scope dark-mode styling to `html.dark` and `body.dark`

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c7fa140832b941a1d458047c8b4