### PR TITLE
refactor: use global button styles on about page

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -235,14 +235,6 @@
 </section>
 
 <style>
-  .btn-primary {
-    @apply inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200;
-  }
-  
-  .btn-secondary {
-    @apply inline-flex items-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200;
-  }
-  
   .brand-name {
     font-family: Georgia, serif;
   }


### PR DESCRIPTION
## Summary
- rely on global `.btn-primary` and `.btn-secondary` styles in about page
- remove component overrides for button classes

## Testing
- `npm test` *(fails: No test files found)*
- `npm run check` *(fails: svelte-check found 60 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c806400832bbc5d56a23bbbebf5