### PR TITLE
Add window check to image preload helpers

### DIFF
--- a/src/lib/services/authorImages.ts
+++ b/src/lib/services/authorImages.ts
@@ -61,6 +61,10 @@ export function toBase64UnicodeSafe(svg: string): string {
 
 // ✅ ADD MISSING EXPORT - Preload helper
 export async function preloadImage(url: string): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => resolve(true);

--- a/src/lib/services/imageHelpers.ts
+++ b/src/lib/services/imageHelpers.ts
@@ -9,7 +9,8 @@ export function getImageWithFallback(url: string | null | undefined): string {
 
 export function preloadImage(url?: string | null): Promise<boolean> {
   if (!url) return Promise.resolve(false);
-  
+  if (typeof window === 'undefined') return Promise.resolve(false);
+
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => resolve(true);


### PR DESCRIPTION
## Summary
- Guard image preloading helpers against non-browser environments
- Prevent `new Image()` from executing on the server

## Testing
- `npm test -- --run --passWithNoTests`
- `npm run check` *(fails: Property 'values' does not exist on type 'ContactActionData' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c72c904554832ba9afacaf1153f85e